### PR TITLE
修复缺少content-Length导致返回411状态码

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function migCdn(options){
             uri: upload_url,
             headers: {
                 'X-CDN-Authentication': options.key,
-                'Content-Type': fileSize
+                'Content-Length': fileSize
             }
         }, function(error, response, body){
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ function migCdn(options){
         file.pipe(request({
             method: 'POST',
             uri: upload_url,
-            headers: {'X-CDN-Authentication': options.key}
+            headers: {
+                'X-CDN-Authentication': options.key,
+                'Content-Type': fileSize
+            }
         }, function(error, response, body){
 
             if(error){


### PR DESCRIPTION
上传文件的时候，请求头缺乏Content-Length字段会导致返回411，报错